### PR TITLE
Allow nulls at pages.LastScanDate field.

### DIFF
--- a/djangorestapi/restapi/models.py
+++ b/djangorestapi/restapi/models.py
@@ -24,7 +24,7 @@ class Pages(models.Model):
     Url = models.URLField("url", max_length=2048)
     SiteID = models.ForeignKey(Sites, db_column="SiteID")
     FoundDateTime = models.DateTimeField("date found")
-    LastScanDate = models.DateTimeField("last scan date")
+    LastScanDate = models.DateTimeField("last scan date", null=True, blank=True)
 
 
 class Persons(models.Model):


### PR DESCRIPTION
В спецификации краулера указано:
"Для этого сайта добавить в таблицу Pages строку с URL равным http://<имя_сайта>/robots.txt и LastScanDate равным null."